### PR TITLE
Proposed fix for issue #3

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -26,6 +26,7 @@ setlocale(LC_ALL, 'en_UK.UTF8');
 ini_set('session.gc_maxlifetime', 2400);   // 40 minute session timeout
 ini_set('session.gc_probability', 1);
 ini_set('session.gc_divisor', 100);
+ini_set('session.cookie_httponly', 1 ); //HTTP only session cookies
 @session_start();
 
 

--- a/app/library/ecl/mvc/layout/html.php
+++ b/app/library/ecl/mvc/layout/html.php
@@ -49,6 +49,7 @@ class Ecl_Mvc_Layout_Html extends Ecl_Mvc_Layout {
 	 * @return  boolean  The operation was successful.
 	 */
 	public function addBreadcrumb($title, $href = null) {
+        $title = $this->escape($title);
 		$this->_breadcrumbs[] = array (
 			'title'  => $title ,
 			'href'   => $href ,


### PR DESCRIPTION
Hi, 
the proposed fix is to escape `$title` argument to `addBreadcrumb`. Furthermore to setting session cookies to HTTP only should hide the session key from Javascript in some browsers. 
