### PR TITLE
LDAP attributes are now variable and can be changed with the local config.

### DIFF
--- a/app/controllers/authenticator.php
+++ b/app/controllers/authenticator.php
@@ -63,25 +63,29 @@ class Authenticator {
 		$ldap = Ecl::factory('Ecl_Ldap', array (
 			'host'        => $this->_model->get('ldap.host') ,
 			'port'        => $this->_model->get('ldap.port') ,
-			'username'    => $username . $this->_model->get('ldap.username_suffix') ,
+			///maintainance test
+			///'username'    => $username . $this->_model->get('ldap.username_suffix') ,
+			'username'    => $username . $this->_model->get('ldap.dn') ,
 			'password'    => $password ,
 			'options'     => $this->_model->get('ldap.options', array()) ,
 			'use_secure'  => $this->_model->get('ldap.use_secure', false) ,
-			'debug'       => false ,
+			'debug'       => $this->_model->get('ldap.debug', false) ,
 		));
-
+		
 		try {
+
+
 			$ldap->connect();
 
 			$base_dn = $this->_model->get('ldap.dn');
-			$filter = "name={$username}";
-			$attrs = array('employeenumber', 'name', 'givenname', 'sn', 'mail');
+			$filter = "uid={$username}";
+			$attrs = array('uidnumber', 'name', 'givenname', 'sn', 'mail');
 
 			$entry_count = $ldap->search($base_dn, $filter, $attrs);
 
 			if ($entry_count>0) {
 				$ldap_row = $ldap->getRow();
-				$user_row['id'] = (isset($ldap_row['employeenumber'])) ? $ldap_row['employeenumber'] : null ;
+				$user_row['id'] = (isset($ldap_row['uidnumber'])) ? $ldap_row['uidnumber'] : null ;
 				$user_row['username'] = (isset($ldap_row['name'])) ? $ldap_row['name'] : null ;
 				$user_row['forename'] = (isset($ldap_row['givenname'])) ? $ldap_row['givenname'] : null ;
 				$user_row['surname'] = (isset($ldap_row['sn'])) ? $ldap_row['sn'] : null ;
@@ -90,11 +94,11 @@ class Authenticator {
 				return $user_row;
 			}
 		} catch (Ecl_Exception_Ldap_Bind $e) {
-			return null;
+			return 3001;
 		} catch (Ecl_Exception_Ldap $e) {
-			return null;
+			return 3002;
 		}
-		return null;
+		return 3003;
 	}// /method
 
 

--- a/app/controllers/signin.php
+++ b/app/controllers/signin.php
@@ -22,8 +22,6 @@ class Controller_Signin extends Ecl_Mvc_Controller {
 
 		// @idea : Include throttling to prevent login spam
 
-		// @idea : Change the built-in authentication options so they are plugins like the local-config ones
-
 		// Call the different authentication options in turn...
 
 		if ($this->model('signin.use_ldap')) {

--- a/install/install_steps/6_authentication.php
+++ b/install/install_steps/6_authentication.php
@@ -138,6 +138,10 @@ if ($config['signin.use_ldap']) {
 		<td class="name">ldap.username_suffix</td>
 		<td><?php out($config['ldap.username_suffix']); ?></td>
 	</tr>
+	<tr>
+        	<td class="name">ldap.debug</td>
+        	<td><?php out(boolval($config['ldap.debug'])); ?></td>
+	</tr>
 	</table>
 	<?php
 } else {

--- a/install/install_steps/install_db.sql
+++ b/install/install_steps/install_db.sql
@@ -11,9 +11,10 @@
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!41000 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 
+SET sql_mode = '';
 
 
 --
@@ -96,7 +97,7 @@ CREATE TABLE `category_code` (
   `code` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`category_id`,`vocabulary`,`code`),
   KEY `vocabulary` (`vocabulary`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -283,7 +284,7 @@ CREATE TABLE `item` (
   KEY `supplier_id` (`supplier_id`),
   KEY `is_parent` (`is_parent`),
   KEY `is_disposed_of` (`is_disposed_of`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -299,7 +300,7 @@ CREATE TABLE `item_category` (
   `item_id` int(10) unsigned NOT NULL DEFAULT '0',
   `category_id` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`item_id`,`category_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -400,7 +401,7 @@ CREATE TABLE `item_tag` (
   `item_id` int(10) unsigned NOT NULL DEFAULT '0',
   `tag_id` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`item_id`,`tag_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
@@ -664,7 +665,7 @@ CREATE TABLE `tag` (
   `tag` varchar(200) NOT NULL DEFAULT '',
   PRIMARY KEY (`tag_id`),
   UNIQUE KEY `tag` (`tag`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 

--- a/new_local/local_config.php
+++ b/new_local/local_config.php
@@ -139,6 +139,18 @@ $config['ldap.options'] = array (
 	LDAP_OPT_REFERRALS         => 0 ,   // Set this option to 0 to cope with Windows Server 2003 Active Directories
 );
 
+//To make the LDAP attributes variable and fitting to the organisation, we need to use this config
+//how is the userid number attribute on your LDAP-server called?
+//$config['ldap.id_column'] = 'uidNumber';
+//how is the username attribute on your LDAP-server called?
+//$config['ldap.username_column'] = 'uid';
+//how is the forename attribute on your LDAP-server called?
+//$config['ldap.forename_column'] = 'givenname';
+//how is the surname attribute on your LDAP-server called?
+//$config['ldap.surname_column'] = 'sn';
+//how is the mail attribute on your LDAP-server called?
+//$config['ldap.mail_column'] = 'mail';
+
 // Set to true to secure the LDAP connection (using start-TLS).
 // Note, to have secure LDAP work correctly, you will need to configure your server's LDAP extension to either:
 // (a) Use the correct certificate.


### PR DESCRIPTION
Kit-Catalogue was not yet able to use LDAP authentication when there were different names for the attributes. Now there is a way for changing the configuration of these variables in the local config file. This file has been updated in new_local, with all new configurations for these names in the comments. If not configured, the application will perform in the same way it used to.